### PR TITLE
ciがファイルサイズ制限にかかって失敗しているのを直す

### DIFF
--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -56,9 +56,9 @@ jobs:
           # ビルドツール
           echo -e "\n" | sudo apt install -y git curl make ca-certificates gnupg lsb-release build-essential
           # Rust
-          curl https://sh.rustup.rs -sSf | sudo -E sh -s -- -y # -Eオプションをつけてsudoで環境変数を読み込む
-          . /etc/skel/.cargo/env # cargoは$HOMEの/etc/skelにインストールされる
-          cargo install ripgrep
+          # curl https://sh.rustup.rs -sSf | sudo -E sh -s -- -y # -Eオプションをつけてsudoで環境変数を読み込む
+          # . /etc/skel/.cargo/env # cargoは$HOMEの/etc/skelにインストールされる
+          # cargo install ripgrep
           # Go
           curl -OL https://go.dev/dl/go1.20.1.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go1.20.1.linux-amd64.tar.gz
@@ -79,13 +79,13 @@ jobs:
           # docker-compose
           sudo curl -L https://github.com/docker/compose/releases/download/v2.4.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
-          # Chrome
-          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo dpkg -i google-chrome-stable_current_amd64.deb
-          # Spotify
-          sudo snap install spotify
-          # UNetbootin
-          wget https://github.com/unetbootin/unetbootin/releases/download/702/unetbootin-linux64-702.bin
+          # # Chrome
+          # wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          # sudo dpkg -i google-chrome-stable_current_amd64.deb
+          # # Spotify
+          # sudo snap install spotify
+          # # UNetbootin
+          # wget https://github.com/unetbootin/unetbootin/releases/download/702/unetbootin-linux64-702.bin
           sudo mv unetbootin-linux64-702.bin /usr/local/bin/unetbootin
           sudo chmod +x /usr/local/bin/unetbootin
           # apt


### PR DESCRIPTION
サイズがでかすぎてGitHub Actionsの制限にかかって失敗するのでいくつか削除する